### PR TITLE
Fixed correct setting of last_confirmed_block_num and added alert to recovered

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "witness-essentials-watcher",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Watcher alerts you in case of missed blocks and changes your signing key automatically",
   "main": "dist/index.js",
   "scripts": {  

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -52,11 +52,13 @@ let watch_witness = async (IS_TESTING, NOTIFY, FAILOVER, DISABLE) => {
     // If a block has been missed before, but witness node has recovered and signed a new block
     if(_g.MISSED_BLOCK_FLAG && witness.last_confirmed_block_num > _g.last_confirmed_block_num) {
       essentials.log(`Recovered on block ${witness.last_confirmed_block_num}`)
+      await send_alerts(`Witness ${_g.witness_data.witness}: Recovered on block ${witness.last_confirmed_block_num}`, `Witness ${_g.witness_data.witness}: Recovered on block ${witness.last_confirmed_block_num}`)
       _g.start_total_missed = _g.current_total_missed = witness.total_missed
       _g.rotation_round = 0
       _g.MISSED_BLOCK_FLAG = false
-      _g.last_confirmed_block_num = witness.last_confirmed_block_num
     }
+
+    _g.last_confirmed_block_num = witness.last_confirmed_block_num
 
      // New missed block?
     if (witness.total_missed > _g.current_total_missed) {


### PR DESCRIPTION
Before, `_g.last_confirmed_block_num` was only updated in case of a missed_block & recovery, even if the witness hadn't signed a block yet. Which is incorrect. Instead, now `_g.last_confirmed_block_num` is updated every round.